### PR TITLE
Fix: --help and -h flags not showing general help (Issue #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2025-06-14
+
+### Fixed
+- Fixed --help and -h flags not showing general help (Issue #41)
+  - Previously these flags were incorrectly passed as arguments to the help command
+  - Now properly shows the full help message when using --help or -h
+- Added --help and -h to the global flags documentation
+
 ## [1.9.0] - 2025-06-09
 
 ### Added

--- a/bin/claude-memory.js
+++ b/bin/claude-memory.js
@@ -1350,6 +1350,7 @@ GLOBAL FLAGS:
   --force, -f                            Skip confirmation prompts
   --debug                                Show debug information for troubleshooting
   --version, -v                          Show version number
+  --help, -h                             Show this help message
 
 ENVIRONMENT VARIABLES:
   CLAUDE_MEMORY_CONFIG                   Path to custom config file
@@ -1814,7 +1815,9 @@ debug('Command parsing complete', {
 
 // Handle help flags
 if (!command || command === 'help' || command === '--help' || command === '-h') {
-  commands.help(cleanArgs[0]);
+  // For --help and -h flags, show general help, not help for a specific command
+  const helpTopic = (command === 'help') ? cleanArgs[0] : null;
+  commands.help(helpTopic);
   process.exit(0);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Transform AI conversations into persistent project intelligence - Universal memory system for Claude",
   "main": "bin/claude-memory.js",
   "type": "module",

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,21 @@ async function runTests() {
     fs.rmSync(verboseTestDir, { recursive: true, force: true });
   });
 
+  // Test 6b: Help flags
+  await test('Help flags (--help and -h)', async() => {
+    const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
+
+    // Test --help flag
+    const { stdout: helpLong } = await execAsync(`node "${cliPath}" --help`);
+    assert(helpLong.includes('Claude Memory'), 'Should show help with --help');
+    assert(helpLong.includes('USAGE:'), 'Should show usage section');
+
+    // Test -h flag
+    const { stdout: helpShort } = await execAsync(`node "${cliPath}" -h`);
+    assert(helpShort.includes('Claude Memory'), 'Should show help with -h');
+    assert(helpShort.includes('USAGE:'), 'Should show usage section');
+  });
+
   // Test 7: Package.json is valid
   await test('Package.json is valid', () => {
     const pkgPath = path.join(packageRoot, 'package.json');


### PR DESCRIPTION
## Summary
This PR fixes a bug where the --help and -h flags were being passed as arguments to the help command instead of triggering the general help display.

## Changes
- Modified help flag handling to show general help for --help and -h flags
- Added --help and -h to the global flags documentation
- Added test coverage for both help flags
- Updated version to 1.9.1 for patch release
- Updated CHANGELOG.md

## Testing
- Added tests for both --help and -h flags
- All tests passing
- Manually verified both flags work correctly

## Related Issues
Fixes #41

🤖 Generated with Claude Code