### PR TITLE
fix: add --help flag support to all subcommands (Issue #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2025-06-14
+
+### Fixed
+- Fixed `--help` flag not working on subcommands (Issue #46)
+  - `task --help`, `export --help`, `import --help`, etc. now show proper help text
+  - All subcommands now recognize both `--help` and `-h` flags
+  - Previously showed "Unknown flag" errors instead of help
+
 ## [1.10.0] - 2025-06-14
 
 ### Added

--- a/bin/claude-memory.js
+++ b/bin/claude-memory.js
@@ -230,6 +230,9 @@ const commands = {
       } else if (arg === '--limit' && args[i + 1]) {
         limit = parseInt(args[i + 1]);
         i++;
+      } else if (arg === '--help' || arg === '-h') {
+        commands.showContextualHelp('search');
+        process.exit(0);
       } else if (arg?.startsWith('--')) {
         console.error(`❌ Unknown flag: ${arg}`);
         console.log('Usage: claude-memory search "query" [--json] [--type TYPE] [--limit N] [path]');
@@ -397,6 +400,12 @@ const commands = {
 
   async pattern(action, ...args) {
     const projectPath = process.cwd();
+
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('pattern');
+      process.exit(0);
+    }
 
     if (action === 'add') {
       const pattern = args[0];
@@ -633,6 +642,12 @@ const commands = {
 
   async task(action, ...args) {
     const projectPath = process.cwd();
+
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('task');
+      process.exit(0);
+    }
 
     if (action === 'add') {
       const description = args[0];
@@ -887,6 +902,9 @@ const commands = {
         i++;
       } else if (arg === '--no-metadata') {
         includeMetadata = false;
+      } else if (arg === '--help' || arg === '-h') {
+        commands.showContextualHelp('export');
+        process.exit(0);
       } else if (arg?.startsWith('--')) {
         console.error(`❌ Unknown flag: ${arg}`);
         console.log('Usage: claude-memory export [filename] [options] [path]');
@@ -1304,6 +1322,12 @@ const commands = {
   session(action, ...args) {
     const projectPath = process.cwd();
 
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('session');
+      process.exit(0);
+    }
+
     if (action === 'start') {
       const sessionName = args[0];
       const context = args[1] || '{}';
@@ -1404,6 +1428,9 @@ const commands = {
         i++;
       } else if (arg === '--dry-run') {
         dryRun = true;
+      } else if (arg === '--help' || arg === '-h') {
+        commands.showContextualHelp('import');
+        process.exit(0);
       } else if (arg?.startsWith('--')) {
         console.error(`❌ Unknown flag: ${arg}`);
         console.log('Usage: claude-memory import <filename> [options] [path]');
@@ -2522,6 +2549,12 @@ const commands = {
     const projectPath = process.cwd();
     const configPath = path.join(projectPath, '.claude', 'config.json');
 
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('config');
+      process.exit(0);
+    }
+
     if (action === 'get') {
       try {
         const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -2554,6 +2587,12 @@ const commands = {
 
   async knowledge(action, ...args) {
     const projectPath = process.cwd();
+
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('knowledge');
+      process.exit(0);
+    }
 
     if (action === 'add') {
       const key = args[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Transform AI conversations into persistent project intelligence - Universal memory system for Claude",
   "main": "bin/claude-memory.js",
   "type": "module",


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes subcommands not recognizing `--help` flags, resolving Issue #46.

### Problem
All subcommands like `task --help`, `export --help`, `import --help` were showing "Unknown flag" errors instead of displaying help text.

### Solution
- Added `--help`/`-h` flag handling to all subcommand functions
- Commands now call `commands.showContextualHelp()` when help flags are detected
- Applied to: task, export, import, search, pattern, session, knowledge, config commands

### Changes
- **bin/claude-memory.js**: Added help flag checking at start of each subcommand function
- **package.json**: Version bump to v1.10.1  
- **CHANGELOG.md**: Documented the fix

### Testing
- ✅ All existing tests pass (25/25)
- ✅ Manual testing confirms `--help` works on all subcommands:
  ```bash
  claude-memory task --help      # ✅ Shows task help
  claude-memory export --help    # ✅ Shows export help  
  claude-memory import --help    # ✅ Shows import help
  claude-memory pattern --help   # ✅ Shows pattern help
  ```

### Impact
- **Type**: Patch release (bug fix)
- **Breaking Changes**: None
- **User Experience**: Standard CLI `--help` convention now works everywhere

### Before/After
**Before**:
```bash
$ claude-memory task --help
❌ Task action must be: add, complete, list, add-bulk, or export
```

**After**:  
```bash
$ claude-memory task --help
✅ Task Management
Manage project tasks, todos, and work tracking
[... detailed help text ...]
```

Ready for v1.10.1 release to resolve this CLI usability issue.

---
Closes #46