### PR TITLE
feat: add summary management commands (Issue #73)

### DIFF
--- a/.claude/context/decisions.md
+++ b/.claude/context/decisions.md
@@ -1,5 +1,5 @@
 # Decision Log
-*Generated: 2025-07-05T23:15:41.043Z | 77 total decisions*
+*Generated: 2025-07-05T23:36:39.934Z | 77 total decisions*
 
 ## Recent Decisions
 ### 6/1/2025: Install Claude Memory

--- a/.claude/context/decisions.md
+++ b/.claude/context/decisions.md
@@ -1,5 +1,5 @@
 # Decision Log
-*Generated: 2025-06-15T22:49:13.791Z | 74 total decisions*
+*Generated: 2025-07-05T23:15:41.043Z | 77 total decisions*
 
 ## Recent Decisions
 ### 6/1/2025: Install Claude Memory

--- a/.claude/context/knowledge.md
+++ b/.claude/context/knowledge.md
@@ -1,5 +1,5 @@
 # Project Knowledge Base
-*Generated: 2025-06-15T22:49:13.787Z | 65 items across 11 categories*
+*Generated: 2025-07-05T23:15:41.034Z | 69 items across 11 categories*
 
 ## Navigation
 - [architecture](#architecture) (4 items)
@@ -10,8 +10,8 @@
 - [implementation](#implementation) (5 items)
 - [progress](#progress) (3 items)
 - [releases](#releases) (6 items)
-- [status](#status) (18 items)
-- [testing](#testing) (7 items)
+- [status](#status) (21 items)
+- [testing](#testing) (8 items)
 - [workflow](#workflow) (14 items)
 
 ## architecture
@@ -151,6 +151,18 @@
 **Value**: GitHub: main branch up-to-date with v1.5.0 release and project knowledge documentation. NPM: v1.5.0 published and available. Local: repository at v1.5.0, global claude-memory v1.5.0 installed, all systems synchronized. Ready for Issues #8-9 development.
 **Updated**: 2025-06-05T00:46:46.757Z
 
+### github_issues_complete
+**Value**: Completed creating all 15 GitHub issues from Rob's feedback: #53-67 covering critical bugs (CLAUDE.md sync, handoff overwrite), high-priority features (git integration, token optimization, export templates), medium enhancements (search context, health dashboard, error messages, interactive mode, config system, test suite, migration), and low-priority items (session duration bug, pattern effectiveness, pagination). All feedback items now tracked in GitHub.
+**Updated**: 2025-06-23T00:29:49.232Z
+
+### github_issues_from_feedback
+**Value**: Created 5 high-priority GitHub issues from Rob's comprehensive feedback: #53 (CLAUDE.md sync bug), #54 (handoff overwrite bug), #55 (git integration), #56 (token optimization), #57 (export templates). Still need to create 10+ medium/low priority issues for remaining feedback items.
+**Updated**: 2025-06-23T00:06:09.666Z
+
+### summaries_feature_status
+**Value**: Implemented summary commands for v1.11.0. Created PR #74 targeting develop branch. Waiting for PR #72 (bug fixes) to merge first, then will rebase and merge.
+**Updated**: 2025-07-05T23:15:21.700Z
+
 ### v1.10.0_features
 **Value**: Export/Import functionality complete with multiple formats (JSON, YAML, CSV, Markdown), filtering options, merge/replace modes, validation, and comprehensive report generation
 **Updated**: 2025-06-14T17:37:22.132Z
@@ -211,6 +223,10 @@
 ### Merge_Test_2
 **Value**: Second test to verify manual sections are preserved during updates
 **Updated**: 2025-06-05T01:04:22.525Z
+
+### TEST_BUG_53
+**Value**: Testing bug fix for stale counts
+**Updated**: 2025-07-05T22:23:42.069Z
 
 ### Test_Merge_System
 **Value**: Testing the new merge implementation with local code

--- a/.claude/context/knowledge.md
+++ b/.claude/context/knowledge.md
@@ -1,5 +1,5 @@
 # Project Knowledge Base
-*Generated: 2025-07-05T23:15:41.034Z | 69 items across 11 categories*
+*Generated: 2025-07-05T23:36:39.929Z | 70 items across 11 categories*
 
 ## Navigation
 - [architecture](#architecture) (4 items)
@@ -9,7 +9,7 @@
 - [feedback](#feedback) (2 items)
 - [implementation](#implementation) (5 items)
 - [progress](#progress) (3 items)
-- [releases](#releases) (6 items)
+- [releases](#releases) (7 items)
 - [status](#status) (21 items)
 - [testing](#testing) (8 items)
 - [workflow](#workflow) (14 items)
@@ -109,6 +109,10 @@
 ### v1.10.2_release
 **Value**: Fixed report command --type flag handling (Issue #48). Both 'report progress' and 'report --type progress' syntaxes now work correctly. Patch release ready for deployment.
 **Updated**: 2025-06-15T22:30:44.569Z
+
+### v1.11.0_release_status
+**Value**: Ready for release - Summary management feature implemented (Issue #73). All tests passing, lint clean, security audit clean. Feature adds generate/list/view commands for .claude/summaries directory.
+**Updated**: 2025-07-05T23:36:39.907Z
 
 ### v1.8.0_release_status
 **Value**: Successfully released v1.8.0 with CLI flags enhancement. Fixed version issue by committing package.json update after merge. NPM publish successful, GitHub release created.

--- a/.claude/context/patterns.md
+++ b/.claude/context/patterns.md
@@ -1,8 +1,8 @@
 # Project Patterns
-*Generated: 2025-06-15T22:49:13.790Z | 54 total patterns*
+*Generated: 2025-07-05T23:15:41.041Z | 55 total patterns*
 
 ## Summary
-- Open Patterns: 42
+- Open Patterns: 43
 - Resolved Patterns: 12
 
 ## Open Patterns
@@ -111,6 +111,13 @@
 - **Effectiveness**: 1
 - **First Seen**: 2025-06-13T02:11:20.601Z
 - **Last Seen**: 2025-06-13T02:11:20.601Z
+- **Frequency**: 1
+
+#### PR merge order strategy (ID: b82ca894)
+- **Description**: When multiple PRs need to merge, always merge bug fixes first (patch versions), then features (minor versions). Rebase feature branches after bug fixes merge to maintain clean history.
+- **Effectiveness**: null
+- **First Seen**: 2025-07-05T23:15:41.014Z
+- **Last Seen**: 2025-07-05T23:15:41.014Z
 - **Frequency**: 1
 
 ### Medium Priority

--- a/.claude/context/patterns.md
+++ b/.claude/context/patterns.md
@@ -1,5 +1,5 @@
 # Project Patterns
-*Generated: 2025-07-05T23:15:41.041Z | 55 total patterns*
+*Generated: 2025-07-05T23:36:39.932Z | 55 total patterns*
 
 ## Summary
 - Open Patterns: 43

--- a/.claude/context/tasks.md
+++ b/.claude/context/tasks.md
@@ -1,5 +1,5 @@
 # Task Management
-*Generated: 2025-07-05T23:15:41.052Z | 22 total tasks*
+*Generated: 2025-07-05T23:36:39.944Z | 22 total tasks*
 
 ## Summary
 - Open: 10

--- a/.claude/context/tasks.md
+++ b/.claude/context/tasks.md
@@ -1,5 +1,5 @@
 # Task Management
-*Generated: 2025-06-15T22:49:13.800Z | 22 total tasks*
+*Generated: 2025-07-05T23:15:41.052Z | 22 total tasks*
 
 ## Summary
 - Open: 10

--- a/.claude/summaries/2025-07-05-test-summary-feature.md
+++ b/.claude/summaries/2025-07-05-test-summary-feature.md
@@ -1,0 +1,28 @@
+# Test Summary Feature
+
+**Date**: 2025-07-05
+**Type**: manual
+**Session**: Evening Development (2025-07-05-evening-development)
+
+## Summary
+
+*Please add your summary content here...*
+
+## Context
+
+### Active Tasks
+- Add task status update command (in-progress, blocked, etc) (low)
+- Consider JSON import/export for task migration (low)
+- Test task with tag (medium)
+- Design and implement v1.5.0 features (Issues #5-9) (medium)
+- Test task (medium)
+
+### Recent Decisions
+- Created comprehensive GitHub issues from feedback
+- Create GitHub issues from Rob's feedback
+- Release v1.10.2 patch for report command fix
+
+### Key Patterns
+- Dogfooding validates design (1 occurrences)
+- Selective git strategy (1 occurrences)
+- Stay synced with automated releases (1 occurrences)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2025-07-05
+
+### Added
+- Summary management commands for `.claude/summaries/` directory (Issue #73)
+  - `summary generate` - Create summaries with contextual templates
+  - `summary list` - List all available summaries
+  - `summary view` - View specific summary content
+  - Summaries include context from current session (tasks, decisions, patterns)
+  - Support for linking summaries to specific sessions
+
+### Changed
+- The previously empty `.claude/summaries/` directory now has functionality
+- Summaries are tracked in memory.json for better integration
+
 ## [1.10.3] - 2025-06-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
 # Claude Project Memory
 
 ## Active Session
-- **Current**: Afternoon Development
-- **Started**: 2025-06-15
+- **Current**: Evening Development
+- **Started**: 2025-07-05
 - **Project**: Claude Memory NPM Package
 
 ## Key Project Knowledge
 
 ### Critical Information
 - **Project Name**: Claude Memory NPM Package
-- **Claude Memory**: v1.10.0
+- **Claude Memory**: v1.11.0
 - **Memory Created**: 2025-06-01
 
 ### Knowledge Base
@@ -32,18 +32,18 @@
 - **unified_design_v1.10.0**: Created unified design proposal addressing user feedback. Phase 1 (v1.10.0) focuses on export/import commands and bulk o...
 - ... and 2 more items
 
-#### status (18 items)
+#### status (21 items)
 - **Parity_Status_v1.5.0**: GitHub: main branch up-to-date with v1.5.0 release and project knowledge documentation. NPM: v1.5.0 published and availa...
 - **v1.6.0_Released**: Successfully released v1.6.0 with 100% user feedback addressed. PRs #13 (Issue #9: Enhanced help) and #14 (Issue #8: CLA...
-- ... and 16 more items
+- ... and 19 more items
 
 #### design (1 items)
 - **CLAUDE_Merge_Strategy**: Section-based merge system: !-- BEGIN MANUAL SECTION -- for user content, !-- BEGIN AUTO SECTION -- for generated conten...
 
-#### testing (7 items)
+#### testing (8 items)
 - **Merge_Test**: Testing the CLAUDE.md merge strategy to ensure manual sections are preserved during auto-updates
 - **Test_Merge_System**: Testing the new merge implementation with local code
-- ... and 5 more items
+- ... and 6 more items
 
 #### implementation (5 items)
 - **Issue_8_Implementation**: Successfully implemented CLAUDE.md merge strategy with section markers (!-- BEGIN MANUAL SECTION: Name --), automatic ba...
@@ -66,19 +66,14 @@
 
 ### Recent Changes
 #### Recent Decisions
-- **2025-06-15**: Release v1.10.2 patch for report command fix
-- **2025-06-14**: Release v1.10.1 as patch for CLI usability
-- **2025-06-14**: Create v1.10.1 patch for --help bug
+- **2025-07-05**: Implement summaries feature for v1.11.0
 
 #### Recent Patterns
-- **2025-06-15**: Test pattern (high)
-- **2025-06-09**: Rebase after major refactoring (high)
-- **2025-06-09**: v1.9.0 feature completion tracking (high)
+- **2025-07-05**: PR merge order strategy (high)
 
 #### Recent Knowledge Updates
-- **2025-06-15**: workflow/git_flow_workflow
-- **2025-06-15**: releases/v1.10.2_release
-- **2025-06-14**: releases/v1.10.1_release
+- **2025-07-05**: status/summaries_feature_status
+- **2025-07-05**: testing/TEST_BUG_53
 
 
 ### Open Patterns
@@ -109,22 +104,22 @@
 
 ## Recent Decisions Log
 
-### 2025-06-15: Release v1.10.2 patch for report command fix
-**Decision**: Release v1.10.2 patch for report command fix
-**Reasoning**: Critical CLI usability fix for report command --type flag handling
-**Alternatives Considered**: Wait for more fixes, Delay release
+### 2025-07-05: Implement summaries feature for v1.11.0
+**Decision**: Implement summaries feature for v1.11.0
+**Reasoning**: User feedback showed the empty .claude/summaries directory was confusing. Implemented generate, list, and view commands to manage project summaries with contextual templates.
+**Alternatives Considered**: Leave directory empty, Remove directory, Document as future feature
 
 
-### 2025-06-14: Release v1.10.1 as patch for CLI usability
-**Decision**: Release v1.10.1 as patch for CLI usability
-**Reasoning**: Critical bug affecting user experience with --help flags - immediate patch release needed
-**Alternatives Considered**: Wait for v1.11.0, Create hotfix branch
+### 2025-06-23: Created comprehensive GitHub issues from feedback
+**Decision**: Created comprehensive GitHub issues from feedback
+**Reasoning**: Successfully created 19 total issues (#53-71) covering all feedback from Rob White IV, including critical bugs, features, and quality improvements
+**Alternatives Considered**: Create only high-priority issues, Skip documentation issues, Implement directly without issues
 
 
-### 2025-06-14: Create v1.10.1 patch for --help bug
-**Decision**: Create v1.10.1 patch for --help bug
-**Reasoning**: Critical CLI usability issue discovered in v1.10.0 - subcommands don't handle --help flags properly
-**Alternatives Considered**: Wait for next major release, Create separate branch
+### 2025-06-23: Create GitHub issues from Rob's feedback
+**Decision**: Create GitHub issues from Rob's feedback
+**Reasoning**: Created 5 high-priority issues based on comprehensive feedback document to address critical bugs and important features
+**Alternatives Considered**: Wait for more feedback, Create all 17 issues at once, Focus only on bugs
 
 
 ## Commands & Workflows
@@ -168,9 +163,9 @@ claude-memory handoff [--format markdown|json]
 
 ## Full Context Files
 For complete information without truncation:
-- 📚 **Knowledge Base**: `.claude/context/knowledge.md` (65 items)
-- 🧩 **All Patterns**: `.claude/context/patterns.md` (54 patterns)
-- 🎯 **Decision Log**: `.claude/context/decisions.md` (74 decisions)
+- 📚 **Knowledge Base**: `.claude/context/knowledge.md` (69 items)
+- 🧩 **All Patterns**: `.claude/context/patterns.md` (55 patterns)
+- 🎯 **Decision Log**: `.claude/context/decisions.md` (77 decisions)
 - ✅ **Task Details**: `.claude/context/tasks.md` (22 tasks)
 
 ## Session Continuation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 
 ### Critical Information
 - **Project Name**: Claude Memory NPM Package
-- **Claude Memory**: v1.11.0
+- **Claude Memory**: v1.10.3
 - **Memory Created**: 2025-06-01
 
 ### Knowledge Base
@@ -55,10 +55,10 @@
 - **git_co_author**: Always include Rob White as co-author in commits: Co-Authored-By: Rob White robwhite4@yahoo.com
 - ... and 12 more items
 
-#### releases (6 items)
+#### releases (7 items)
 - **v1.8.0_release_status**: Successfully released v1.8.0 with CLI flags enhancement. Fixed version issue by committing package.json update after mer...
 - **v1.8.0_v1.8.1_releases**: Successfully released v1.8.0 (CLI flags) and v1.8.1 (housekeeping). Key learnings: 1) Version-first workflow critical, 2...
-- ... and 4 more items
+- ... and 5 more items
 
 #### documentation (1 items)
 - **wiki_documentation_complete**: Created comprehensive GitHub wiki with 12 new pages covering all aspects of Claude Memory v1.9.0. All wiki links use hyp...
@@ -72,6 +72,7 @@
 - **2025-07-05**: PR merge order strategy (high)
 
 #### Recent Knowledge Updates
+- **2025-07-05**: releases/v1.11.0_release_status
 - **2025-07-05**: status/summaries_feature_status
 - **2025-07-05**: testing/TEST_BUG_53
 
@@ -163,7 +164,7 @@ claude-memory handoff [--format markdown|json]
 
 ## Full Context Files
 For complete information without truncation:
-- 📚 **Knowledge Base**: `.claude/context/knowledge.md` (69 items)
+- 📚 **Knowledge Base**: `.claude/context/knowledge.md` (70 items)
 - 🧩 **All Patterns**: `.claude/context/patterns.md` (55 patterns)
 - 🎯 **Decision Log**: `.claude/context/decisions.md` (77 decisions)
 - ✅ **Task Details**: `.claude/context/tasks.md` (22 tasks)

--- a/README.md
+++ b/README.md
@@ -439,6 +439,23 @@ cmem report tasks monthly.md --from 2024-01-01
 - **Progress**: Timeline of activities and completion metrics
 - **Sprint**: 2-week activity summary for agile workflows
 
+### Summary Management
+```bash
+# Create a new summary with context
+cmem summary generate "Sprint Retrospective"
+
+# Link to specific session
+cmem summary generate "Feature Complete" --session 2025-01-15-morning
+
+# List all summaries
+cmem summary list
+
+# View a summary
+cmem summary view 2025-01-15-sprint-retrospective
+```
+
+The `.claude/summaries/` directory stores narrative documentation that complements your structured memory data. Generated summaries include context from your current session (tasks, decisions, patterns) and provide a template for adding your insights.
+
 ### AI Assistant Handoffs
 ```bash
 # Generate comprehensive handoff summary

--- a/bin/claude-memory.js
+++ b/bin/claude-memory.js
@@ -2564,6 +2564,214 @@ const commands = {
     return sections.join('\n');
   },
 
+  async summary(action, ...args) {
+    const projectPath = process.cwd();
+    const memory = new ClaudeMemory(projectPath);
+    const summariesDir = path.join(projectPath, '.claude', 'summaries');
+
+    // Handle help flags
+    if (action === '--help' || action === '-h') {
+      commands.showContextualHelp('summary');
+      process.exit(0);
+    }
+
+    if (!action) {
+      console.error('❌ Summary action required');
+      console.log('Usage: claude-memory summary <generate|list|view> [options]');
+      return;
+    }
+
+    switch (action) {
+      case 'generate': {
+        // Parse options
+        let sessionId = null;
+        let summaryType = 'manual';
+        let title = null;
+        
+        for (let i = 0; i < args.length; i++) {
+          if (args[i] === '--session' && args[i + 1]) {
+            sessionId = args[i + 1];
+            i++;
+          } else if (args[i] === '--type' && args[i + 1]) {
+            summaryType = args[i + 1];
+            i++;
+          } else if (!title) {
+            title = args[i];
+          }
+        }
+
+        if (!title) {
+          console.error('❌ Summary title required');
+          console.log('Usage: claude-memory summary generate "Title" [--session <id>] [--type <type>]');
+          return;
+        }
+
+        try {
+          // Generate summary content
+          const timestamp = new Date().toISOString();
+          const dateStr = timestamp.split('T')[0];
+          const filename = `${dateStr}-${title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')}.md`;
+          const filepath = path.join(summariesDir, filename);
+
+          // Create summary content
+          let content = `# ${title}\n\n`;
+          content += `**Date**: ${dateStr}\n`;
+          content += `**Type**: ${summaryType}\n`;
+          
+          if (sessionId) {
+            const session = memory.sessions.find(s => s.id === sessionId);
+            if (session) {
+              content += `**Session**: ${session.name} (${session.id})\n`;
+            }
+          } else if (memory.currentSession) {
+            content += `**Session**: ${memory.currentSession.name} (${memory.currentSession.id})\n`;
+          }
+          
+          content += `\n## Summary\n\n`;
+          content += `*Please add your summary content here...*\n\n`;
+          
+          // Add context sections
+          content += `## Context\n\n`;
+          content += `### Active Tasks\n`;
+          const activeTasks = memory.getTasks('open').slice(0, 5);
+          if (activeTasks.length > 0) {
+            activeTasks.forEach(task => {
+              content += `- ${task.description} (${task.priority})\n`;
+            });
+          } else {
+            content += `- No active tasks\n`;
+          }
+          
+          content += `\n### Recent Decisions\n`;
+          const recentDecisions = memory.getRecentDecisions(3);
+          if (recentDecisions.length > 0) {
+            recentDecisions.forEach(decision => {
+              content += `- ${decision.decision}\n`;
+            });
+          } else {
+            content += `- No recent decisions\n`;
+          }
+          
+          content += `\n### Key Patterns\n`;
+          const openPatterns = memory.patterns.filter(p => p.status === 'open' && p.priority === 'high').slice(0, 3);
+          if (openPatterns.length > 0) {
+            openPatterns.forEach(pattern => {
+              content += `- ${pattern.pattern} (${pattern.frequency} occurrences)\n`;
+            });
+          } else {
+            content += `- No high-priority patterns\n`;
+          }
+
+          // Ensure summaries directory exists
+          if (!fs.existsSync(summariesDir)) {
+            fs.mkdirSync(summariesDir, { recursive: true });
+          }
+
+          // Write summary file
+          fs.writeFileSync(filepath, content, 'utf8');
+          
+          // Record summary in memory
+          if (!memory.summaries) {
+            memory.summaries = [];
+          }
+          memory.summaries.push({
+            id: `sum_${Date.now()}`,
+            filename,
+            title,
+            type: summaryType,
+            sessionId: sessionId || memory.currentSession?.id,
+            created: timestamp,
+            path: filepath
+          });
+          memory.saveMemory();
+
+          console.log(`✅ Summary created: ${filename}`);
+          console.log(`📝 Path: ${filepath}`);
+          console.log(`💡 Edit the file to add your summary content`);
+        } catch (error) {
+          console.error('❌ Error creating summary:', error.message);
+        }
+        break;
+      }
+
+      case 'list': {
+        try {
+          // Ensure summaries directory exists
+          if (!fs.existsSync(summariesDir)) {
+            console.log('📂 No summaries found (directory does not exist)');
+            return;
+          }
+
+          // List all summary files
+          const files = fs.readdirSync(summariesDir)
+            .filter(f => f.endsWith('.md'))
+            .sort()
+            .reverse(); // Most recent first
+
+          if (files.length === 0) {
+            console.log('📂 No summaries found');
+            console.log('💡 Create one with: claude-memory summary generate "Title"');
+            return;
+          }
+
+          console.log(`📚 Found ${files.length} summaries:\n`);
+          
+          files.forEach(file => {
+            const filepath = path.join(summariesDir, file);
+            const stats = fs.statSync(filepath);
+            const content = fs.readFileSync(filepath, 'utf8');
+            const titleMatch = content.match(/^# (.+)$/m);
+            const title = titleMatch ? titleMatch[1] : 'Untitled';
+            const dateStr = new Date(stats.mtime).toISOString().split('T')[0];
+            
+            console.log(`📄 ${file}`);
+            console.log(`   Title: ${title}`);
+            console.log(`   Modified: ${dateStr}`);
+            console.log(`   Size: ${(stats.size / 1024).toFixed(1)} KB`);
+            console.log('');
+          });
+        } catch (error) {
+          console.error('❌ Error listing summaries:', error.message);
+        }
+        break;
+      }
+
+      case 'view': {
+        const filename = args[0];
+        
+        if (!filename) {
+          console.error('❌ Summary filename required');
+          console.log('Usage: claude-memory summary view <filename>');
+          console.log('Use "claude-memory summary list" to see available summaries');
+          return;
+        }
+
+        try {
+          // Add .md extension if not provided
+          const file = filename.endsWith('.md') ? filename : `${filename}.md`;
+          const filepath = path.join(summariesDir, file);
+          
+          if (!fs.existsSync(filepath)) {
+            console.error(`❌ Summary not found: ${file}`);
+            console.log('Use "claude-memory summary list" to see available summaries');
+            return;
+          }
+
+          const content = fs.readFileSync(filepath, 'utf8');
+          console.log(content);
+        } catch (error) {
+          console.error('❌ Error viewing summary:', error.message);
+        }
+        break;
+      }
+
+      default:
+        console.error(`❌ Unknown summary action: ${action}`);
+        console.log('Available actions: generate, list, view');
+        console.log('Use "claude-memory summary --help" for more information');
+    }
+  },
+
   async config(action, key, value) {
     const projectPath = process.cwd();
     const configPath = path.join(projectPath, '.claude', 'config.json');
@@ -2806,7 +3014,8 @@ UTILITIES:
   📥 import <filename> [options]         Import memory data with merge/replace options
   📊 report [type] [options]             Generate project reports and analytics
   🤖 context [path]                      Get AI integration context (JSON)
-  🔄 handoff [options] [path]            Generate AI assistant handoff summary
+  🔄 handoff [options] [path]            Generate AI handoff summary (saves to HANDOFF.md)
+  📝 summary <action> [options]          Manage project summaries (generate, list, view)
   ❓ help [command]                      Show help (add command name for details)
 
 GLOBAL FLAGS:
@@ -3090,6 +3299,36 @@ QUICK EXAMPLES:
           '💡 JSON format is useful for further processing or integration',
           '💡 --save creates timestamped files for historical tracking',
           '💡 Reports directory can be tracked in git or ignored as needed'
+        ]
+      },
+
+      summary: {
+        title: '📝 Summary Management',
+        description: 'Create and manage project summaries in the .claude/summaries directory',
+        commands: {
+          'summary generate <title> [options]': 'Create a new summary with template',
+          'summary list': 'List all available summaries',
+          'summary view <filename>': 'View a specific summary'
+        },
+        options: {
+          '--session <id>': 'Link summary to specific session (generate)',
+          '--type <type>': 'Summary type: manual, session, daily, weekly (default: manual)'
+        },
+        examples: [
+          'cmem summary generate "Sprint 1 Retrospective"',
+          'cmem summary generate "Feature Complete" --session 2025-01-15-morning',
+          'cmem summary generate "Weekly Review" --type weekly',
+          'cmem summary list',
+          'cmem summary view 2025-01-15-sprint-1-retrospective',
+          'cmem summary view 2025-01-15-sprint-1-retrospective.md'
+        ],
+        tips: [
+          '💡 Summaries provide narrative context alongside structured data',
+          '💡 Generated summaries include context from current session',
+          '💡 Edit generated files to add your own insights and notes',
+          '💡 Use summaries for sprint retrospectives and milestone documentation',
+          '💡 Summary files are markdown format for easy editing and reading',
+          '💡 Summaries complement the automated handoff and report features'
         ]
       },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Transform AI conversations into persistent project intelligence - Universal memory system for Claude",
   "main": "bin/claude-memory.js",
   "type": "module",

--- a/test/test.js
+++ b/test/test.js
@@ -414,7 +414,7 @@ async function runTests() {
     const { stdout } = await execAsync(`node "${cliPath}" summary generate "Test Summary"`);
     assert(stdout.includes('Summary created'), 'Should create summary');
     assert(stdout.includes('test-summary.md'), 'Should show filename');
-    
+
     // Clean up
     const summariesDir = path.join('.claude', 'summaries');
     if (fs.existsSync(summariesDir)) {
@@ -429,15 +429,15 @@ async function runTests() {
 
   await test('Summary command - list', async() => {
     const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
-    
+
     // First create a summary
     await execAsync(`node "${cliPath}" summary generate "List Test"`);
-    
+
     // Then list summaries
     const { stdout } = await execAsync(`node "${cliPath}" summary list`);
     assert(stdout.includes('Found'), 'Should list summaries');
     assert(stdout.includes('list-test.md'), 'Should show summary file');
-    
+
     // Clean up
     const summariesDir = path.join('.claude', 'summaries');
     if (fs.existsSync(summariesDir)) {
@@ -452,20 +452,20 @@ async function runTests() {
 
   await test('Summary command - view', async() => {
     const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
-    
+
     // First create a summary
     await execAsync(`node "${cliPath}" summary generate "View Test"`);
-    
+
     // Get the filename
     const summariesDir = path.join('.claude', 'summaries');
     const files = fs.readdirSync(summariesDir);
     const viewFile = files.find(f => f.includes('view-test'));
-    
+
     // View the summary
     const { stdout } = await execAsync(`node "${cliPath}" summary view ${viewFile}`);
     assert(stdout.includes('View Test'), 'Should display summary title');
     assert(stdout.includes('## Summary'), 'Should display summary content');
-    
+
     // Clean up
     if (viewFile) {
       fs.unlinkSync(path.join(summariesDir, viewFile));

--- a/test/test.js
+++ b/test/test.js
@@ -408,6 +408,70 @@ async function runTests() {
     fs.rmSync(customDir, { recursive: true, force: true });
   });
 
+  // Summary command tests
+  await test('Summary command - generate', async() => {
+    const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
+    const { stdout } = await execAsync(`node "${cliPath}" summary generate "Test Summary"`);
+    assert(stdout.includes('Summary created'), 'Should create summary');
+    assert(stdout.includes('test-summary.md'), 'Should show filename');
+    
+    // Clean up
+    const summariesDir = path.join('.claude', 'summaries');
+    if (fs.existsSync(summariesDir)) {
+      const files = fs.readdirSync(summariesDir);
+      files.forEach(file => {
+        if (file.includes('test-summary')) {
+          fs.unlinkSync(path.join(summariesDir, file));
+        }
+      });
+    }
+  });
+
+  await test('Summary command - list', async() => {
+    const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
+    
+    // First create a summary
+    await execAsync(`node "${cliPath}" summary generate "List Test"`);
+    
+    // Then list summaries
+    const { stdout } = await execAsync(`node "${cliPath}" summary list`);
+    assert(stdout.includes('Found'), 'Should list summaries');
+    assert(stdout.includes('list-test.md'), 'Should show summary file');
+    
+    // Clean up
+    const summariesDir = path.join('.claude', 'summaries');
+    if (fs.existsSync(summariesDir)) {
+      const files = fs.readdirSync(summariesDir);
+      files.forEach(file => {
+        if (file.includes('list-test')) {
+          fs.unlinkSync(path.join(summariesDir, file));
+        }
+      });
+    }
+  });
+
+  await test('Summary command - view', async() => {
+    const cliPath = path.join(packageRoot, 'bin', 'claude-memory.js');
+    
+    // First create a summary
+    await execAsync(`node "${cliPath}" summary generate "View Test"`);
+    
+    // Get the filename
+    const summariesDir = path.join('.claude', 'summaries');
+    const files = fs.readdirSync(summariesDir);
+    const viewFile = files.find(f => f.includes('view-test'));
+    
+    // View the summary
+    const { stdout } = await execAsync(`node "${cliPath}" summary view ${viewFile}`);
+    assert(stdout.includes('View Test'), 'Should display summary title');
+    assert(stdout.includes('## Summary'), 'Should display summary content');
+    
+    // Clean up
+    if (viewFile) {
+      fs.unlinkSync(path.join(summariesDir, viewFile));
+    }
+  });
+
   console.log(`\n📊 Test Results: ${passCount}/${testCount} passed`);
 
   if (passCount === testCount) {


### PR DESCRIPTION
## Summary
- Implements summary management commands for the `.claude/summaries/` directory
- Addresses user feedback about the empty summaries directory having no functionality
- Adds generate, list, and view commands for managing project summaries

## Changes

### New Commands
- `summary generate <title>` - Creates a summary with contextual template
- `summary list` - Lists all available summaries
- `summary view <filename>` - Displays summary content

### Features
- Generated summaries include context from current session (tasks, decisions, patterns)
- Summaries can be linked to specific sessions with `--session` flag
- Support for different summary types with `--type` flag
- Summaries are tracked in memory.json for integration
- Comprehensive help documentation added

### Technical Details
- Summaries stored in `.claude/summaries/` directory as markdown files
- Filename format: `YYYY-MM-DD-title-slug.md`
- Metadata tracked in memory.json summaries array
- Added 3 new tests for summary functionality
- All existing tests pass (29/29)

## Test Plan
- [x] `npm test` - All 29 tests pass
- [x] Tested `summary generate` creates files correctly
- [x] Tested `summary list` shows summaries with metadata
- [x] Tested `summary view` displays content
- [x] Verified help documentation shows correctly
- [x] Updated README with examples

## Related
- Fixes #73 - Feature: Implement summary commands for .claude/summaries directory
- Based on user experience report showing demand for this functionality